### PR TITLE
feat: add search organization clients action

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 [update device](#action-update-device) - Update a device in the network <br>
 [remove device](#action-remove-device) - Remove a device from the network <br>
 [list device clients](#action-list-device-clients) - List clients connected to a device <br>
+[search organization clients](#action-search-organization-clients) - Search for a client in an organization by MAC address <br>
 [list l3 firewall rules](#action-list-l3-firewall-rules) - List Layer 3 firewall rules for a network <br>
 [update l3 firewall rules](#action-update-l3-firewall-rules) - Update Layer 3 firewall rules for a network <br>
 [list l7 firewall rules](#action-list-l7-firewall-rules) - List Layer 7 firewall rules for a network <br>
@@ -338,6 +339,61 @@ action_result.data.\*.ip | string | `ip` | |
 action_result.data.\*.mac | string | | |
 action_result.summary.total_clients | numeric | | 5 |
 action_result.message | string | | Total device clients: 5 |
+summary.total_objects | numeric | | 1 |
+summary.total_objects_successful | numeric | | 1 |
+
+## action: 'search organization clients'
+
+Search for a client in an organization by MAC address
+
+Type: **investigate** <br>
+Read only: **True**
+
+This action searches for a client across all networks in an organization using the client's MAC address. Returns client details and network appearance records.
+
+#### Action Parameters
+
+PARAMETER | REQUIRED | DESCRIPTION | TYPE | CONTAINS
+--------- | -------- | ----------- | ---- | --------
+**organization_id** | required | Organization ID | string | `organization id` |
+**mac** | required | MAC address of the client to search for | string | `mac address` |
+**per_page** | optional | Number of records per page (3-5, default 5) | numeric | |
+
+#### Action Output
+
+DATA PATH | TYPE | CONTAINS | EXAMPLE VALUES
+--------- | ---- | -------- | --------------
+action_result.status | string | | success failed |
+action_result.parameter.organization_id | string | `organization id` | 123456789012 |
+action_result.parameter.mac | string | `mac address` | 00:11:22:33:44:55 |
+action_result.parameter.per_page | numeric | | 5 |
+action_result.data.\*.clientId | string | | |
+action_result.data.\*.mac | string | `mac address` | |
+action_result.data.\*.manufacturer | string | | |
+action_result.data.\*.records.\*.network.id | string | `network id` | |
+action_result.data.\*.records.\*.network.name | string | | |
+action_result.data.\*.records.\*.network.organizationId | string | `organization id` | |
+action_result.data.\*.records.\*.network.timeZone | string | | |
+action_result.data.\*.records.\*.ip | string | `ip` | |
+action_result.data.\*.records.\*.ip6 | string | `ipv6` | |
+action_result.data.\*.records.\*.ip6Local | string | `ipv6` | |
+action_result.data.\*.records.\*.vlan | string | | |
+action_result.data.\*.records.\*.ssid | string | | |
+action_result.data.\*.records.\*.switchport | string | | |
+action_result.data.\*.records.\*.firstSeen | string | | |
+action_result.data.\*.records.\*.lastSeen | string | | |
+action_result.data.\*.records.\*.os | string | | |
+action_result.data.\*.records.\*.user | string | | |
+action_result.data.\*.records.\*.recentDeviceMac | string | `mac address` | |
+action_result.data.\*.records.\*.recentDeviceSerial | string | `serial` | |
+action_result.data.\*.records.\*.recentDeviceName | string | | |
+action_result.data.\*.records.\*.recentDeviceConnection | string | | |
+action_result.data.\*.records.\*.status | string | | |
+action_result.data.\*.records.\*.description | string | | |
+action_result.summary.client_id | string | | |
+action_result.summary.mac | string | `mac address` | |
+action_result.summary.total_records | numeric | | 3 |
+action_result.message | string | | Successfully retrieved client search results |
 summary.total_objects | numeric | | 1 |
 summary.total_objects_successful | numeric | | 1 |
 

--- a/actions/ciscomeraki_search_organization_clients.py
+++ b/actions/ciscomeraki_search_organization_clients.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python
+# File: ciscomeraki_search_organization_clients.py
+#
+# Copyright (c) 2025 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+import phantom.app as phantom
+
+import ciscomeraki_consts as consts
+from actions import BaseAction
+
+
+class SearchOrganizationClients(BaseAction):
+    """Class to handle the search organization clients action."""
+
+    def execute(self):
+        """Execute the search organization clients action.
+
+        Returns:
+            bool: Success/failure
+        """
+        self._connector.save_progress(consts.EXECUTION_START_MSG.format("search_organization_clients"))
+
+        # Validate required parameters
+        organization_id = self._param.get("organization_id")
+        if not organization_id:
+            return self._action_result.set_status(phantom.APP_ERROR, consts.ERROR_REQUIRED_PARAM.format(key="organization_id"))
+
+        mac = self._param.get("mac")
+        if not mac:
+            return self._action_result.set_status(phantom.APP_ERROR, consts.ERROR_REQUIRED_PARAM.format(key="mac"))
+
+        # Validate per_page if provided
+        per_page = self._param.get("per_page")
+        if per_page:
+            try:
+                per_page = int(per_page)
+                if not 3 <= per_page <= 5:
+                    return self._action_result.set_status(phantom.APP_ERROR, "Parameter 'per_page' must be between 3 and 5")
+            except ValueError:
+                return self._action_result.set_status(phantom.APP_ERROR, consts.ERROR_INVALID_INT_PARAM.format(key="per_page"))
+
+        # Prepare parameters
+        params = {"mac": mac}
+        if per_page:
+            params["perPage"] = per_page
+
+        # Make REST call
+        ret_val, response = self._connector._utils._make_rest_call(
+            endpoint=consts.SEARCH_ORGANIZATION_CLIENTS.format(organization_id=organization_id),
+            action_result=self._action_result,
+            method="get",
+            params=params,
+        )
+
+        if phantom.is_fail(ret_val):
+            return self._action_result.get_status()
+
+        # Process response - API returns a single client object with records
+        self._action_result.add_data(response)
+
+        # Build summary
+        summary = {
+            "client_id": response.get("clientId", ""),
+            "mac": response.get("mac", ""),
+            "total_records": len(response.get("records", [])),
+        }
+        self._action_result.update_summary(summary)
+
+        return self._action_result.set_status(
+            phantom.APP_SUCCESS,
+            consts.ACTION_SUCCESS_RESPONSE.format(
+                action=" ".join([i.capitalize() if idx > 0 else i for idx, i in enumerate(self._connector.get_action_identifier().split("_"))])
+            ),
+        )

--- a/ciscomeraki.json
+++ b/ciscomeraki.json
@@ -1202,6 +1202,245 @@
             "versions": "EQ(*)"
         },
         {
+            "action": "search organization clients",
+            "identifier": "search_organization_clients",
+            "description": "Search for a client in an organization by MAC address",
+            "verbose": "This action searches for a client across all networks in an organization using the client's MAC address. Returns client details and network appearance records.",
+            "type": "investigate",
+            "read_only": true,
+            "parameters": {
+                "organization_id": {
+                    "description": "Organization ID",
+                    "data_type": "string",
+                    "required": true,
+                    "primary": true,
+                    "order": 0,
+                    "contains": [
+                        "organization id"
+                    ]
+                },
+                "mac": {
+                    "description": "MAC address of the client to search for",
+                    "data_type": "string",
+                    "required": true,
+                    "order": 1,
+                    "contains": [
+                        "mac address"
+                    ]
+                },
+                "per_page": {
+                    "description": "Number of records per page (3-5, default 5)",
+                    "data_type": "numeric",
+                    "order": 2
+                }
+            },
+            "render": {
+                "type": "table",
+                "width": 12,
+                "height": 5,
+                "title": "Client Search Results"
+            },
+            "output": [
+                {
+                    "data_path": "action_result.status",
+                    "data_type": "string",
+                    "example_values": [
+                        "success",
+                        "failed"
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.organization_id",
+                    "data_type": "string",
+                    "example_values": [
+                        "123456789012"
+                    ],
+                    "contains": [
+                        "organization id"
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.mac",
+                    "data_type": "string",
+                    "example_values": [
+                        "00:11:22:33:44:55"
+                    ],
+                    "contains": [
+                        "mac address"
+                    ]
+                },
+                {
+                    "data_path": "action_result.parameter.per_page",
+                    "data_type": "numeric",
+                    "example_values": [
+                        5
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.clientId",
+                    "data_type": "string",
+                    "column_name": "Client ID",
+                    "column_order": 0
+                },
+                {
+                    "data_path": "action_result.data.*.mac",
+                    "data_type": "string",
+                    "column_name": "MAC Address",
+                    "column_order": 1,
+                    "contains": [
+                        "mac address"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.manufacturer",
+                    "data_type": "string",
+                    "column_name": "Manufacturer",
+                    "column_order": 2
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.network.id",
+                    "data_type": "string",
+                    "contains": [
+                        "network id"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.network.name",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.network.organizationId",
+                    "data_type": "string",
+                    "contains": [
+                        "organization id"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.network.timeZone",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.ip",
+                    "data_type": "string",
+                    "contains": [
+                        "ip"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.ip6",
+                    "data_type": "string",
+                    "contains": [
+                        "ipv6"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.ip6Local",
+                    "data_type": "string",
+                    "contains": [
+                        "ipv6"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.vlan",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.ssid",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.switchport",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.firstSeen",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.lastSeen",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.os",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.user",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.recentDeviceMac",
+                    "data_type": "string",
+                    "contains": [
+                        "mac address"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.recentDeviceSerial",
+                    "data_type": "string",
+                    "contains": [
+                        "serial"
+                    ]
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.recentDeviceName",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.recentDeviceConnection",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.status",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.data.*.records.*.description",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.summary.client_id",
+                    "data_type": "string"
+                },
+                {
+                    "data_path": "action_result.summary.mac",
+                    "data_type": "string",
+                    "contains": [
+                        "mac address"
+                    ]
+                },
+                {
+                    "data_path": "action_result.summary.total_records",
+                    "data_type": "numeric",
+                    "example_values": [
+                        3
+                    ]
+                },
+                {
+                    "data_path": "action_result.message",
+                    "data_type": "string",
+                    "example_values": [
+                        "Successfully retrieved client search results"
+                    ]
+                },
+                {
+                    "data_path": "summary.total_objects",
+                    "data_type": "numeric",
+                    "example_values": [
+                        1
+                    ]
+                },
+                {
+                    "data_path": "summary.total_objects_successful",
+                    "data_type": "numeric",
+                    "example_values": [
+                        1
+                    ]
+                }
+            ],
+            "versions": "EQ(*)"
+        },
+        {
             "action": "list l3 firewall rules",
             "identifier": "list_l3_firewall_rules",
             "description": "List Layer 3 firewall rules for a network",

--- a/ciscomeraki_consts.py
+++ b/ciscomeraki_consts.py
@@ -47,6 +47,7 @@ LIST_DEVICES = "/networks/{network_id}/devices"
 UPDATE_DEVICE = "/networks/{network_id}/devices/{serial}"
 REMOVE_DEVICE = "/networks/{network_id}/devices/{serial}"
 LIST_DEVICE_CLIENTS = "/devices/{serial}/clients"
+SEARCH_ORGANIZATION_CLIENTS = "/organizations/{organization_id}/clients/search"
 
 # Adaptive Policy endpoints
 LIST_ADAPTIVE_POLICIES = "/organizations/{organization_id}/adaptivePolicy/policies"


### PR DESCRIPTION
### Features

Add new action to search for clients across all networks in an organization by MAC address. Uses the Meraki API endpoint GET /organizations/{organizationId}/clients/search.

- Add SEARCH_ORGANIZATION_CLIENTS endpoint constant
- Create SearchOrganizationClients action class
- Add action definition with full output schema

### Manual Documentation

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
